### PR TITLE
Assertions whose output begins with "<<FATAL>>" end tests immediately.

### DIFF
--- a/fixture.go
+++ b/fixture.go
@@ -60,13 +60,17 @@ func (this *Fixture) Run(name string, test func(fixture *Fixture)) {
 // So is a convenience method for reporting assertion failure messages,
 // from the many assertion functions found in github.com/smarty/assertions/should.
 // Example: this.So(actual, should.Equal, expected)
+// Example: this.So(actual, must.Equal, expected) // ends test IMMEDIATELY in case of failure
 func (this *Fixture) So(actual any, assert assertion, expected ...any) bool {
+	const fatalPrefix = "<<FATAL>>"
 	failure := assert(actual, expected...)
-	failed := len(failure) > 0
-	if failed {
+	if strings.HasPrefix(failure, fatalPrefix) {
+		failure = strings.TrimPrefix(failure, fatalPrefix)
+		this.t.Fatalf(reports.FailureReport(failure, reports.StackTrace()))
+	} else if len(failure) > 0 {
 		this.fail(failure)
 	}
-	return !failed
+	return len(failure) == 0
 }
 
 // Assert tests a boolean which, if not true, marks the current test case as failed and


### PR DESCRIPTION
...via `*testing.T.Fatalf`.

This change is meant to be released in concert with https://github.com/smarty/assertions/pull/55, which introduces a new `must` package which prepends the aforementioned prefix in failure cases. This addresses cases where an error early in a test should kill a test immediately. Here are a few examples of how we've solved this up until this PR:

### Length checks before assertions:

Old way:

```
if !this.So(collection, should.HaveLength, 2) {
    return // we don't have enough items in the collection for upcoming assertions
}
this.So(collection[1].Whatever, should.Equal, "something")
```

New way:

```
this.So(collection, must.HaveLength, 2) // <- new 'must' package ends failed test immediately
this.So(collection[1].Whatever, should.Equal, "Something")
```

### Error checking before subsequent assertions:

Old way:

```
value, err := SomeOperationThatCouldFail()
if !this.So(err, should.BeNil) {
    return
}
this.So(value, should.Equal, 42)
```

New way:

```
value, err := SomeOperationThatCouldFail()
this.So(err, must.BeNil)
this.So(value, should.Equal, 42)
```
